### PR TITLE
Add details about the sensor which triggered the alarm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ $RECYCLE.BIN/
 # Operating System Files
 # =========================
 *.bak
+
+logs/*

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ alarm_control_panel:
     code_panel_disarm_required: [True if you need a code to be sent to physical panel on disarming, Default True]
     code_arm_required: [True if you want a code to need to be entered in HA UI prior to arming, Default False]
     code_disarm_required: [True if you want a code to need to be entered in HA UI prior to disarming, Default True]
-    sensor_names: [Optional mapping from sensor ID to name in JSON format for more user friendly triggered information]
+    sensor_names: [Optional mapping from sensor ID to name for more user friendly triggered information]
 ```
 
 Example:
@@ -35,7 +35,10 @@ alarm_control_panel:
     code_panel_disarm_required: True
     code_arm_required: False
     code_disarm_required: False
-    sensor_names: '{"1":"Front door", "4":"Garden door", "6":"Playroom"}'
+    sensor_names: 
+      1: "Front door"
+      2: "Garden door"
+      3: "Bedroom"
 ```
 
 Note 1: Because my serial cable presents as a HID device the format is /dev/hidraw[x], others that present as serial may be at /dev/ttyUSB0 or similar. Use the following command line to identity the appropriate device
@@ -45,8 +48,22 @@ $ dmesg | grep usb
 $ dmesg | grep hid
 ```
 
-
 Note 2: if you supply a code, this is used as the default code to arm/disarm it
+
+## Usage in automation
+With the following automation setup, you'll get a notification when alarm is triggerd with the id and name (if you configured sensor_names) of the sensor that triggered it.
+
+```
+  trigger:
+  - entity_id: alarm_control_panel.jablotron_alarm
+    platform: state
+    to: triggered
+  condition: []
+  action:
+  - data_template:
+      message: ALARM! {{ trigger.to_state.attributes.triggered_by }}
+    service: notify.notify
+```
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ alarm_control_panel:
     code_panel_disarm_required: [True if you need a code to be sent to physical panel on disarming, Default True]
     code_arm_required: [True if you want a code to need to be entered in HA UI prior to arming, Default False]
     code_disarm_required: [True if you want a code to need to be entered in HA UI prior to disarming, Default True]
+    sensor_names: [Optional mapping from sensor ID to name in JSON format for more user friendly triggered information]
 ```
 
 Example:
@@ -34,6 +35,7 @@ alarm_control_panel:
     code_panel_disarm_required: True
     code_arm_required: False
     code_disarm_required: False
+    sensor_names: '{"1":"Front door", "4":"Garden door", "6":"Playroom"}'
 ```
 
 Note 1: Because my serial cable presents as a HID device the format is /dev/hidraw[x], others that present as serial may be at /dev/ttyUSB0 or similar. Use the following command line to identity the appropriate device

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -291,7 +291,7 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                             else:
                                 return state
                         else:
-                            _LOGGER.warn("Unknown status packet is %s", packet[2:8])
+                            _LOGGER.debug("Unknown status packet is %s", packet[2:8])
 
                     elif byte_two == 62: # '>' symbol is received on startup
                         _LOGGER.info("Startup response packet is: %s", packet[1:8])

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -335,8 +335,8 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                         return STATE_ALARM_TRIGGERED
 
                     else:
-                        if self._state == STATE_ALARM_TRIGGERED:
-                            _LOGGER.debug("Unknown packet when triggered %s", packet[1:8])
+                        # FOR REVERSE ENGINEERING ONLY: will produce A LOT of logs
+                        #_LOGGER.debug("Unknown packet when triggered %s", packet[1:8])
                         pass
 
                 else:

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -182,9 +182,10 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
             b'B': STATE_ALARM_ARMED_NIGHT, # Set (Zone A & B)
             b'C': STATE_ALARM_ARMED_AWAY, # Set (Zone A, B & C)
             b'D': STATE_ALARM_TRIGGERED, #  This was triggered via '24 hour' sensor, when unset
+            b'E': STATE_ALARM_TRIGGERED, # Triggered when zone A is armed 
             b'G': STATE_ALARM_TRIGGERED, # This was trigerred vis s standard sensor, when set
-            b'Q': STATE_ALARM_PENDING, # Setting (Zone A)
-            b'R': STATE_ALARM_PENDING, # Setting (Zones A & B)
+            b'Q': STATE_ALARM_ARMING, # Setting (Zone A)
+            b'R': STATE_ALARM_ARMING, # Setting (Zones A & B)
             b'S': STATE_ALARM_ARMING, # Setting (Full)
             b'\t': "?",
             b'\n': "?",
@@ -282,7 +283,7 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                         state = ja82codes.get(packet[2:3]) # the state is in the 3rd packet
 
                         if state is None:
-                            _LOGGER.debug("Unknown status packet is %s", packet[:8])
+                            _LOGGER.debug("Unknown status packet is %s", packet[2:3])
                             pass
 
                         elif state != "Heartbeat?" and state !="Key Press" and state !="?" :
@@ -330,7 +331,8 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
         send_code = ""
 
         if self._config[CONF_CODE_PANEL_DISARM_REQUIRED]:
-            if code == "":
+            # Use code from config if and onlfy is none is entered by user and setup as not required
+            if code is None and not self._config[CONF_CODE_DISARM_REQUIRED]:
                 code = self._code
             send_code = code
 

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -290,7 +290,10 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                         elif state is not None:
                             if state != self._state:
                                 _LOGGER.debug("Recognized state change to %s from packet %s", state, state_byte)
-                            return state
+                            if state == STATE_ALARM_TRIGGERED and self._triggered_by is None:
+                                pass # wait for _triggered_by to be set before returning triggered state
+                            else:
+                                return state
                         else:
                             _LOGGER.warn("Unknown status packet is %s", packet[2:8])
 
@@ -309,7 +312,10 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                             if self._triggered_by != triggered_sensor:
                                 _LOGGER.info("Alarm triggered by sensor %s", triggered_sensor)
                                 self._triggered_by = triggered_sensor
-                                self.schedule_update_ha_state() # push attribute update to HA
+                                if self._state != STATE_ALARM_TRIGGERED:
+                                    return STATE_ALARM_TRIGGERED
+                                else:
+                                    self.schedule_update_ha_state() # push attribute update to HA
 
                     else:
                         #if self._state == STATE_ALARM_TRIGGERED:

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -1,4 +1,4 @@
-"""This platform enables the possibility to control a MQTT alarm."""
+"""This platform enables the possibility to control a Jablotron alarm."""
 import logging
 import re
 import time
@@ -6,6 +6,7 @@ import voluptuous as vol
 import asyncio
 import threading
 import json
+from datetime import timedelta, datetime
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.const import (
@@ -197,20 +198,37 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
         try:
             self._f = open(self._file_path, 'rb', 64)
 
+            lastTriggerTime = None
+
             while not self._stop.is_set():
+
+                time.sleep(1) # read state once every second, no need for more!
 
                 #self._lock.acquire()
 
                 new_state = self._read()
 
                 if new_state != self._state:
-                    _LOGGER.info("Jablotron state change: %s to %s", self._state, new_state )
+                    _LOGGER.info("Jablotron state change detected: %s to %s", self._state, new_state)
+                    if new_state == STATE_ALARM_TRIGGERED and self._triggered_by is None:
+                        _LOGGER.debug("Alarm triggered but source not known yet")
+
+                        # wait for _triggered_by to be set before returning triggered state, but not more that 10 seconds
+                        if lastTriggerTime is not None and (datetime.now() - lastTriggerTime).seconds < 10: 
+                            continue 
+                        elif lastTriggerTime is None:
+                            lastTriggerTime = datetime.now()
+                            continue
+
+                    elif new_state == STATE_ALARM_DISARMED:
+                        lastTriggerTime = None # clear last trigger time
+                        self._triggered_by = None # clear triggered_by
+                    
+                    # Update state & notify home assistant
                     self._state = new_state
                     asyncio.run_coroutine_threadsafe(self._update(), self._hass.loop)
                         
                 #self._lock.release()
-
-                time.sleep(1) # read state once every second, no need for more!
 
         except Exception as ex:
             _LOGGER.error('Unexpected error: %s', format(ex) )
@@ -242,20 +260,22 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                     self._model = 'Jablotron JA-80 Series'
                     byte_two = int.from_bytes(packet[1:2], byteorder='big', signed=False)
                     
+                    # Startup packet
+                    if byte_two == 62: # '>' symbol is received on startup
+                        _LOGGER.info("Startup response packet is: %s", packet[1:8])
+
                     # Status packet
-                    if byte_two == 1: 
+                    elif byte_two == 1: 
                         # and byte_two <= 8: # and byte_two != 2: # all 2nd packets I have seen are between 1 and 8, but 2 packets sometimes have trigger message 
 
-                        #_LOGGER.debug("packet is %s", packet[:8])
                         state_byte = packet[2:3]
-
+                    
                         # heartbeats or null
                         if state_byte in (b'\xed', b'\xff', b'\x00'):
                             state = "ignore" # no change 
                         # Stable states
                         elif state_byte == b'@': 
                             state = STATE_ALARM_DISARMED
-                            self._triggered_by = None # clear triggered_by
                         elif state_byte in (b'Q', b'R', b'S') and state == STATE_ALARM_DISARMED:
                             state = STATE_ALARM_ARMING # Zone A; A&B; A&B&C
                         elif state_byte == b'A':
@@ -278,44 +298,45 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                         elif state_byte in (b'\xa4', b'\xa0', b'\xb8') and self._state == STATE_ALARM_DISARMING:
                             state = STATE_ALARM_DISARMING
                         # Keypress 
-                        if state_byte in (b'\x80', b'\x81', b'\x82', b'\x83', b'\x84', b'\x85', b'\x86', b'\x87', b'\x88', b'\x89', b'\x8e', b'\x8f'):
+                        elif state_byte in (b'\x80', b'\x81', b'\x82', b'\x83', b'\x84', b'\x85', b'\x86', b'\x87', b'\x88', b'\x89', b'\x8e', b'\x8f'):
                             state = "ignore" # no change
 
                         if state == "ignore":
                             pass
                         elif state is not None:
-                            if state != self._state:
-                                _LOGGER.debug("Recognized state change to %s from packet %s", state, state_byte)
-                            if state == STATE_ALARM_TRIGGERED and self._triggered_by is None:
-                                pass # wait for _triggered_by to be set before returning triggered state
-                            else:
-                                return state
+                            return state
                         else:
                             _LOGGER.debug("Unknown status packet is %s", packet[2:8])
 
-                    elif byte_two == 62: # '>' symbol is received on startup
-                        _LOGGER.info("Startup response packet is: %s", packet[1:8])
+                    # Packets x07?F*\x1* contains the id of the device which triggered the alarm
+                    elif (byte_two == 7 and self._triggered_by is None and 
+                            (
+                                (packet[2:4] == b'GF' and packet[5:7] == b'\x1f<') or # when away
+                                (packet[2:4] == b'EF' and packet[5:7] == b'\x19<')  # when home
+                            )): 
+                        _LOGGER.debug("Sensor status packet is: %s", packet[1:8])
+                        sensor_id = int.from_bytes(packet[4:5], byteorder='big', signed=False)
+                        triggered_sensor = "%s: %s" % (sensor_id, self._config[CONF_CODE_SENSOR_NAMES].get(sensor_id, '?'))
+                        _LOGGER.info("Alarm triggered by sensor %s", triggered_sensor)
+                        self._triggered_by = triggered_sensor
+                        return STATE_ALARM_TRIGGERED
 
-                    elif byte_two == 7 and packet[2:4] in (b'GF', b'EF') and self._triggered_by is None:
-                        # Packets x07?F*\x1* contains the id of the device which triggered the alarm
-                        if (
-                                (packet[2:4] == b'GF' and packet[5:7] == b'\x1f<')  or #when away
-                                (packet[2:4] == b'EF' and packet[5:7] == b'\x19<') # when home
-                            ): 
-                            _LOGGER.debug("Sensor status packet is: %s", packet[1:8])
-                            sensor_id = int.from_bytes(packet[4:5], byteorder='big', signed=False)
-                            triggered_sensor = "%s: %s" % (sensor_id, self._config[CONF_CODE_SENSOR_NAMES].get(sensor_id, '?'))
-                            if self._triggered_by != triggered_sensor:
-                                _LOGGER.info("Alarm triggered by sensor %s", triggered_sensor)
-                                self._triggered_by = triggered_sensor
-                                if self._state != STATE_ALARM_TRIGGERED:
-                                    return STATE_ALARM_TRIGGERED
-                                else:
-                                    self.schedule_update_ha_state() # push attribute update to HA
+                    # Packets x07G*\x1* contains the id of the device which have been sabotaged
+                    elif (byte_two == 7 and self._triggered_by is None and 
+                            (
+                                (packet[2:3] == b'G' and packet[4:6] == b'\x1f<')  or # when away
+                                (packet[2:3] == b'G' and packet[4:6] == b'\x19<') # when home
+                            )): 
+                        _LOGGER.debug("Sensor status packet is: %s", packet[1:8])
+                        sensor_id = int.from_bytes(packet[3:4], byteorder='big', signed=False)
+                        triggered_sensor = "%s: %s (sabotage)" % (sensor_id, self._config[CONF_CODE_SENSOR_NAMES].get(sensor_id, '?'))
+                        _LOGGER.info("Alarm triggered by sabotaged sensor %s", triggered_sensor)
+                        self._triggered_by = triggered_sensor
+                        return STATE_ALARM_TRIGGERED
 
                     else:
-                        #if self._state == STATE_ALARM_TRIGGERED:
-                        #    _LOGGER.debug("Unknown packet is %s", packet[1:8])
+                        if self._state == STATE_ALARM_TRIGGERED:
+                            _LOGGER.debug("Unknown packet when triggered %s", packet[1:8])
                         pass
 
                 else:

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -157,6 +157,11 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
         code = self._code
         if code is None:
             return None
+
+        # Return None if no code needed in HA
+        if not self._config[CONF_CODE_ARM_REQUIRED] and not self._config[CONF_CODE_DISARM_REQUIRED]:
+            return None
+
         if isinstance(code, str) and re.search('^\\d+$', code):
             return alarm.FORMAT_NUMBER
         return alarm.FORMAT_TEXT
@@ -304,7 +309,7 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                         #    _LOGGER.debug("Unknown packet is %s", packet[1:8])
                         pass
 
-                else:         
+                else:
                     _LOGGER.error("The data stream is not recongisable as a JA-82 control panel. Please raise an issue at https://github.com/mattsaxon/HASS-Jablotron80/issues with this packet info [%s]", packet)
                     self._stop.set()
 

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -256,7 +256,7 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                         elif state_byte == b'@': 
                             state = STATE_ALARM_DISARMED
                             self._triggered_by = None # clear triggered_by
-                        elif state_byte in (b'Q', b'R', b'S'):
+                        elif state_byte in (b'Q', b'R', b'S') and state == STATE_ALARM_DISARMED:
                             state = STATE_ALARM_ARMING # Zone A; A&B; A&B&C
                         elif state_byte == b'A':
                             state = STATE_ALARM_ARMED_HOME

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -295,7 +295,7 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                     elif byte_two == 62: # '>' symbol is received on startup
                         _LOGGER.info("Startup response packet is: %s", packet[1:8])
 
-                    elif byte_two == 7 and self._state == STATE_ALARM_TRIGGERED:
+                    elif byte_two == 7 and self._state == STATE_ALARM_TRIGGERED and self._triggered_by == "?":
                         # Alarm is triggered, look into \x07?F*\x1?< message to fetch the device which triggered the alarm
                         if (
                                 (packet[2:4] == b'GF' and packet[5:7] == b'\x1f<')  or #when away

--- a/custom_components/Jablotron80/alarm_control_panel.py
+++ b/custom_components/Jablotron80/alarm_control_panel.py
@@ -40,7 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_CODE_PANEL_ARM_REQUIRED, default=False): cv.boolean,
     vol.Optional(CONF_CODE_PANEL_DISARM_REQUIRED, default=True): cv.boolean,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_CODE_SENSOR_NAMES): cv.string
+    vol.Optional(CONF_CODE_SENSOR_NAMES, default={}): {int: cv.string},
 })
 
 ATTR_CHANGED_BY = "changed_by"
@@ -92,10 +92,6 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
         self._wait_task = None
 
         try:
-            self._sensor_names = {}
-            if self._config[CONF_CODE_SENSOR_NAMES] is not None:
-                self._sensor_names = json.loads(self._config[CONF_CODE_SENSOR_NAMES])
-
             hass.bus.async_listen('homeassistant_stop', self.shutdown_threads)
 
             from concurrent.futures import ThreadPoolExecutor
@@ -308,7 +304,7 @@ class JablotronAlarm(alarm.AlarmControlPanelEntity):
                             ): 
                             _LOGGER.debug("Sensor status packet is: %s", packet[1:8])
                             sensor_id = int.from_bytes(packet[4:5], byteorder='big', signed=False)
-                            triggered_sensor = "%s: %s" % (sensor_id, self._sensor_names.get(str(sensor_id), '?'))
+                            triggered_sensor = "%s: %s" % (sensor_id, self._config[CONF_CODE_SENSOR_NAMES].get(sensor_id, '?'))
                             if self._triggered_by != triggered_sensor:
                                 _LOGGER.info("Alarm triggered by sensor %s", triggered_sensor)
                                 self._triggered_by = triggered_sensor


### PR DESCRIPTION
This quite large PR mainly adds a `triggered_by ` attribute to the alarm state. 
It's recognized from packets I found around the "triggered" state packet with the following pattern: `x07?F*\x1*`. I'm curious to see if this works with other installations or only mine.

I also refactored quite a bit the read method for more stable and precise state recognition (especially for temporary states).

With this changes I'm able to replace the SMS from the communicator module (which will soon not work anymore for me as 2G is being shut down) which is my main motivation for using this component.

I'm happy to discuss the changes and to help others if something not working with their installation.